### PR TITLE
fix: admins should be able to modify or delete social links

### DIFF
--- a/backend/apps/sociallink/api_views.py
+++ b/backend/apps/sociallink/api_views.py
@@ -13,4 +13,4 @@ class GroupSocialLinkViewSet(ModelViewSet):
     serializer_class = GroupSocialLinkSerializer
 
     def list(self, request):
-        raise MethodNotAllowed("GET", detail='Method "GET" not allowed')
+        raise MethodNotAllowed("GET")

--- a/backend/apps/sociallink/permissions.py
+++ b/backend/apps/sociallink/permissions.py
@@ -9,10 +9,13 @@ from .models import SocialLink
 class SocialLinkPermission(permissions.BasePermission):
     def has_permission(self, request: HttpRequest, view):
         user = request.user
-        group = Group.objects.filter(slug=request.data.get("group")).first()
-        if request.method == "get":
-            return True
-        return user.is_superuser or (group and group.is_admin(request.user))
+
+        if view.action == "create":
+            group_slug = request.data.get("group")
+            group = Group.objects.filter(slug=group_slug).first()
+            return group is None or group.is_admin(user)
+
+        return True
 
     def has_object_permission(
         self, request: HttpRequest, view, obj: SocialLink

--- a/backend/apps/sociallink/permissions.py
+++ b/backend/apps/sociallink/permissions.py
@@ -20,4 +20,7 @@ class SocialLinkPermission(permissions.BasePermission):
     def has_object_permission(
         self, request: HttpRequest, view, obj: SocialLink
     ):
-        return any(g.is_admin(request.user) for g in obj.group_set.all())
+        user = request.user
+        group_set = obj.group_set.all()  # A social link could be associated with multiple groups in theory (but not in practice)
+
+        return any(group.is_admin(user) for group in group_set)

--- a/backend/apps/sociallink/permissions.py
+++ b/backend/apps/sociallink/permissions.py
@@ -20,6 +20,9 @@ class SocialLinkPermission(permissions.BasePermission):
     def has_object_permission(
         self, request: HttpRequest, view, obj: SocialLink
     ):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
         user = request.user
         group_set = obj.group_set.all()  # A social link could be associated with multiple groups in theory (but not in practice)
 


### PR DESCRIPTION
# Description

Fix some bugs on social links: admins of a group cannot update or remove a social link.


