### PR TITLE
fix: link to my profile redirects to 404 on legacy pages

### DIFF
--- a/frontend/src/legacy/utils/wrapAndRenderLegacyCode.tsx
+++ b/frontend/src/legacy/utils/wrapAndRenderLegacyCode.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import axios from 'axios';
 
+import { AuthProvider } from '#shared/context/Auth.context';
 import { CustomThemeProvider } from '#shared/context/CustomTheme.context';
 import { ToastProvider } from '#shared/context/Toast.context';
 
@@ -60,11 +61,13 @@ export const wrapAndRenderLegacyCode = (
       <CustomThemeProvider>
         <ThemeProvider theme={theme}>
           <QueryClientProvider client={queryClient}>
-            <ToastProvider>
-              <BrowserRouter>
-                <div className="react-legacy-container">{element}</div>
-              </BrowserRouter>
-            </ToastProvider>
+            <AuthProvider>
+              <ToastProvider>
+                <BrowserRouter>
+                  <div className="react-legacy-container">{element}</div>
+                </BrowserRouter>
+              </ToastProvider>
+            </AuthProvider>
           </QueryClientProvider>
         </ThemeProvider>
       </CustomThemeProvider>


### PR DESCRIPTION
# Description

Solved a bug where the user was redirected to 404 when clicking on the User Menu > My Profile on legacy django pages
