### PR TITLE
fix: min date for membership end

### DIFF
--- a/frontend/src/modules/group/view/shared/MembershipFormFields.tsx
+++ b/frontend/src/modules/group/view/shared/MembershipFormFields.tsx
@@ -94,7 +94,7 @@ export function MembershipFormFields({
           />
           <DateField
             label={t('group.form.endDate.label')}
-            disablePast
+            minDate={formValues.beginDate}
             value={formValues.endDate}
             onChange={(val) => {
               updateFormValues({ endDate: val ?? undefined });


### PR DESCRIPTION
# Description

Fix: end date of a group membership should be after the begine date, not after today.


