### PR TITLE
Handle error when sending emails

### DIFF
--- a/backend/apps/account/utils.py
+++ b/backend/apps/account/utils.py
@@ -31,12 +31,22 @@ def send_email_confirmation(email, request: HttpRequest) -> None:
         "validation_link": request.build_absolute_uri(path),
     }
 
-    send_email(
-        subject="Activation de votre compte Nantral Platform",
-        to=email.email,
-        template_name="email-confirmation",
-        context=context,
-    )
+    try:
+        send_email(
+            subject="Activation de votre compte Nantral Platform",
+            to=email.email,
+            template_name="email-confirmation",
+            context=context,
+        )
+    except Exception:
+        messages.error(
+            request,
+            (
+                "Une erreur est survenue lors de l'envoi du mail. "
+                "Merci de contacter l'administrateur."
+            ),
+        )
+        return
 
     if request:
         if not email.is_ecn_email():


### PR DESCRIPTION
Si une erreur survient lors de l'envoi d'un mail de confirmation, par exemple si il y a un problème de certificat, le processus s’interrompt. C'est problématique notamment lors de la création de compte puisque le compte n'est pas finalisé lorsque le mail est envoyé.

Cette modification de la fonction d'envoi permet de ne pas propager l'erreur à la fonction d'origine, tout en indiquant à l'utilisateur que le mail n'a pas été envoyé.
